### PR TITLE
Fixed issues when working with ctools content type and added readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Commerce Custom Product
+
+## Features
+
+The module provides the new field type "Line item type reference" with this
+field type you can define which additional line item types belong to a module.  
+When adding a product to the cart the referenced line item types are taken in
+account and if a referenced line item type exposes field to the end-users the
+field can be edited by them.
+
+Shipped with support for ctools content type "entity field". So you can use it
+with Panels / Panelizer.
+
+## Usage
+
+  1. Create line item types containing the fields you'd like to provide for 
+  product customization.
+  2. Place a field of the type "Line item type reference" onto the product 
+  display node you want to make customizable.
+  3. Configure the "Add to cart" on your product display node display settings 
+  to handle a "Extra line item types field".
+  4. Edit the product display node and select the line item types you'd like to
+  attach to this product when adding it into the cart.
+  5. Profit!

--- a/commerce_custom_product.module
+++ b/commerce_custom_product.module
@@ -415,7 +415,7 @@ function commerce_custom_product_add_to_cart_form_submit($form, &$form_state) {
           // Create the new product line item of the same type.
           $line_item = entity_create('commerce_line_item', array(
             'type' => $line_item->type,
-            'order_id' => 0,
+            'order_id' => $order->order_id,
             'data' => $line_item->data,
           ));
         }

--- a/commerce_custom_product.module
+++ b/commerce_custom_product.module
@@ -468,33 +468,72 @@ function commerce_custom_product_field_formatter_info_alter(&$info) {
 }
 
 /**
- * Implements hook_form_FORM_ID_alter().
+ * Returns an array with a list of line item type / product reference fields.
  *
- * Alters field display overview.
+ * @param string $entity_type
+ *   The entity type to check.
+ * @param string|NULL $bundle
+ *   The bundle to check.
+ *
+ * @return array
+ *   List of line item type / product reference fields. The array is keyed by:
+ *   - line_item_type_ref_fields: array of relevant line item type reference
+ *     fields.
+ *   - product_ref_fields: array of relevant product reference fields.
  */
-function commerce_custom_product_form_field_ui_display_overview_form_alter(&$form, $form_state) {
-  // Check if we have both product reference and line item type reference fields.
-  $instances = field_info_instances($form['#entity_type'], $form['#bundle']);
-  $line_item_type_ref_fields = $product_ref_fields = array();
+function commerce_custom_product_get_field_options($entity_type, $bundle = NULL) {
+  $cache = &drupal_static(__FUNCTION__, array());
+  $cid = $entity_type . ':' . $bundle;
+  if (isset($cache[$cid])) {
+    return $cache[$cid];
+  }
+
+  $product_ref_fields = $line_item_type_ref_fields = array();
+  $instances = field_info_instances($entity_type, $bundle);
+  if (!$bundle) {
+    $all_instances = array();
+    foreach ($instances as $bundle_instances) {
+      $all_instances += $bundle_instances;
+    }
+    $instances = $all_instances;
+  }
   foreach ($instances as $instance) {
     $field = field_info_field($instance['field_name']);
     if ($field['type'] == 'commerce_custom_product_line_item_type_reference') {
       $line_item_type_ref_fields[$instance['field_name']] = $instance['label'];
     }
     elseif ($field['type'] == 'commerce_product_reference') {
-      $product_ref_fields[] = $instance['field_name'];
+      $product_ref_fields[$instance['field_name']] = $instance['field_name'];
     }
   }
 
-  if (!empty($line_item_type_ref_fields) && !empty($product_ref_fields)) {
-    foreach ($product_ref_fields as $field_name) {
+  $cache[$cid] = array(
+    'line_item_type_ref_fields' => $line_item_type_ref_fields,
+    'product_ref_fields' => $product_ref_fields,
+  );
+  return $cache[$cid];
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter() for field_ui_display_overview_form.
+ *
+ * Alters field display overview.
+ */
+function commerce_custom_product_form_field_ui_display_overview_form_alter(&$form, $form_state) {
+  // Check if we have both product reference and line item type reference
+  // fields.
+  $instances = field_info_instances($form['#entity_type'], $form['#bundle']);
+  $field_options = commerce_custom_product_get_field_options($form['#entity_type'], $form['#bundle']);
+
+  if (!empty($field_options['line_item_type_ref_fields']) && !empty($field_options['product_ref_fields'])) {
+    foreach ($field_options['product_ref_fields'] as $field_name) {
       $extra_line_items_field = $instances[$field_name]['display'][$form['#view_mode']]['settings']['extra_line_items_field'];
       if (!empty($form_state['values']['fields'][$field_name]['settings_edit_form']['settings']['extra_line_items_field'])) {
         $extra_line_items_field = $form_state['values']['fields'][$field_name]['settings_edit_form']['settings']['extra_line_items_field'];
       }
 
-      // Update field formatter settings summary with info about extra line items
-      // field.
+      // Update field formatter settings summary with info about extra line
+      // items field.
       if (!empty($form['fields'][$field_name]['settings_summary']['#markup'])) {
         $items = explode('<br />', $form['fields'][$field_name]['settings_summary']['#markup']);
         $last = array_pop($items);
@@ -505,14 +544,64 @@ function commerce_custom_product_form_field_ui_display_overview_form_alter(&$for
 
       // Add form element for extra line items field configuration.
       if (!empty($form['fields'][$field_name]['format']['settings_edit_form']['settings'])) {
-        $form['fields'][$field_name]['format']['settings_edit_form']['settings']['extra_line_items_field'] = array(
-          '#type' => 'select',
-          '#title' => t('Extra line item types field'),
-          '#description' => t('Choose a field that should be used as a source for configuration for any additional line items that should be added to the order with this product.'),
-          '#default_value' => $extra_line_items_field,
-          '#options' => array(0 => t('- None -')) + $line_item_type_ref_fields,
-        );
+        $field_settings = $instances[$field_name]['display'][$form['#view_mode']]['settings'];
+        if (!empty($form_state['values']['fields'][$field_name]['settings_edit_form']['settings']['extra_line_items_field'])) {
+          $field_settings = $form_state['values']['fields'][$field_name]['settings_edit_form']['settings'];
+        }
+        $form['fields'][$field_name]['format']['settings_edit_form']['settings'] += commerce_custom_product_field_formatter_settings_form_element($field_settings, $form['#entity_type'], $form['#bundle']);
       }
     }
   }
+}
+
+/**
+ * Implements hook_field_formatter_settings_form_alter().
+ *
+ * Ctools content type support for this field.
+ */
+function commerce_custom_product_field_formatter_settings_form_alter(&$settings_form, &$context) {
+  $context_name = key($context['form']['context']['#options']);
+  if (!empty($context['form']['context']['#default_value'])) {
+    $context_name = $context['form']['context']['#default_value'];
+  }
+  $pane_context = (isset($context['form_state']['contexts'][$context_name])) ? $context['form_state']['contexts'][$context_name] : NULL;
+  $entity_type = end($pane_context->type);
+  $field_settings = $context['instance']['display'][$context['view_mode']]['settings'];
+  $settings_form += commerce_custom_product_field_formatter_settings_form_element($field_settings, $entity_type);
+}
+
+/**
+ * Returns extra line item types field settings element.
+ *
+ * @param array $field_settings
+ *   The current field settings.
+ * @param string $entity_type
+ *   The entity type to check.
+ * @param string|NULL $bundle
+ *   The bundle to check.
+ *
+ * @return array
+ *   The configuration element(s).
+ */
+function commerce_custom_product_field_formatter_settings_form_element($field_settings, $entity_type, $bundle = NULL) {
+  $element = array();
+  // Check if we have both product reference and line item type reference
+  // fields.
+  $field_options = commerce_custom_product_get_field_options($entity_type, $bundle);
+  if (!empty($field_options['line_item_type_ref_fields']) && !empty($field_options['product_ref_fields'])) {
+    foreach ($field_options['product_ref_fields'] as $field_name) {
+      $extra_line_items_field = NULL;;
+      if (!empty($field_settings['extra_line_items_field'])) {
+        $extra_line_items_field = $field_settings['extra_line_items_field'];
+      }
+      $element['extra_line_items_field'] = array(
+        '#type' => 'select',
+        '#title' => t('Extra line item types field'),
+        '#description' => t('Choose a field that should be used as a source for configuration for any additional line items that should be added to the order with this product.'),
+        '#default_value' => $extra_line_items_field,
+        '#options' => array(0 => t('- None -')) + $field_options['line_item_type_ref_fields'],
+      );
+    }
+  }
+  return $element;
 }

--- a/commerce_custom_product.module
+++ b/commerce_custom_product.module
@@ -301,11 +301,24 @@ function commerce_custom_product_form_commerce_cart_add_to_cart_form_alter(&$for
   foreach (field_info_instances($form_state['context']['entity_type'], $entity->{$bundle_key}) as $instance) {
     $field = field_info_field($instance['field_name']);
     if ($field['type'] == 'commerce_product_reference') {
-      if (empty($instance['display'][$view_mode])) {
-        $view_mode = 'default';
+      // Custom settings.
+      if (is_array($view_mode)) {
+        $view_mode_settings = $view_mode;
       }
-      if ($instance['display'][$view_mode]['type'] == 'commerce_cart_add_to_cart_form') {
-        $extra_line_items_field = $instance['display'][$view_mode]['settings']['extra_line_items_field'];
+      // View mode by name.
+      elseif (!empty($instance['display'][$view_mode])) {
+        $view_mode_settings = $instance['display'][$view_mode];
+      }
+      // Default view mode settings.
+      elseif (isset($instance['display']['default'])) {
+        $view_mode_settings = $instance['display']['default'];
+      }
+      // All failed, just avoid notice.
+      else {
+        $view_mode_settings = array('type' => '');
+      }
+      if ($view_mode_settings['type'] == 'commerce_cart_add_to_cart_form') {
+        $extra_line_items_field = $view_mode_settings['settings']['extra_line_items_field'];
       }
     }
   }

--- a/commerce_custom_product.module
+++ b/commerce_custom_product.module
@@ -295,30 +295,26 @@ function commerce_custom_product_form_commerce_cart_add_to_cart_form_alter(&$for
   $entity_info = entity_get_info($form_state['context']['entity_type']);
   $bundle_key = $entity_info['entity keys']['bundle'];
 
-  // Check field configuration and see which field is to be used as the source for
-  // configuration.
+  // If the display information contains settings use them, otherwise it's the
+  // name of a view mode.
   $extra_line_items_field = NULL;
-  foreach (field_info_instances($form_state['context']['entity_type'], $entity->{$bundle_key}) as $instance) {
-    $field = field_info_field($instance['field_name']);
-    if ($field['type'] == 'commerce_product_reference') {
-      // Custom settings.
-      if (is_array($view_mode)) {
-        $view_mode_settings = $view_mode;
-      }
-      // View mode by name.
-      elseif (!empty($instance['display'][$view_mode])) {
-        $view_mode_settings = $instance['display'][$view_mode];
-      }
-      // Default view mode settings.
-      elseif (isset($instance['display']['default'])) {
-        $view_mode_settings = $instance['display']['default'];
-      }
-      // All failed, just avoid notice.
-      else {
-        $view_mode_settings = array('type' => '');
-      }
-      if ($view_mode_settings['type'] == 'commerce_cart_add_to_cart_form') {
-        $extra_line_items_field = $view_mode_settings['settings']['extra_line_items_field'];
+  if (is_array($view_mode)) {
+    if (isset($view_mode['settings']['extra_line_items_field'])) {
+      $extra_line_items_field = $view_mode['settings']['extra_line_items_field'];
+    }
+  }
+  else {
+    // Check field configuration and see which field is to be used as the source
+    // for configuration.
+    foreach (field_info_instances($form_state['context']['entity_type'], $entity->{$bundle_key}) as $instance) {
+      $field = field_info_field($instance['field_name']);
+      if ($field['type'] == 'commerce_product_reference') {
+        if (empty($instance['display'][$view_mode])) {
+          $view_mode = 'default';
+        }
+        if ($instance['display'][$view_mode]['type'] == 'commerce_cart_add_to_cart_form') {
+          $extra_line_items_field = $instance['display'][$view_mode]['settings']['extra_line_items_field'];
+        }
       }
     }
   }

--- a/commerce_custom_product.module
+++ b/commerce_custom_product.module
@@ -103,7 +103,7 @@ function commerce_custom_product_commerce_line_item_type_info() {
       $line_item_types[$type] = array(
         'name' => check_plain($line_item_type['name']),
         'description' => t('A customizable product line item type.'),
-        'product' => TRUE,
+        'product' => FALSE,
         'add_form_submit_value' => t('Add product'),
         'base' => 'commerce_product_line_item',
       );
@@ -215,7 +215,7 @@ function commerce_custom_product_field_validate($entity_type, $entity, $field, $
   foreach ($items as $delta => $item) {
     if (!empty($item['target_id'])) {
       $type = commerce_line_item_type_load($item['target_id']);
-      if (!$type || !$type['product']) {
+      if (!$type || $type['product']) {
         $errors[$field['field_name']][$langcode][$delta][] = array(
           'error' => 'commerce_custom_product_line_item_type_reference_invalid',
           'message' => t('%name: Invalid line item type referenced.', array('%name' => $instance['label'])),
@@ -252,7 +252,7 @@ function commerce_custom_product_field_widget_form(&$form, &$form_state, $field,
   if ($instance['widget']['type'] == 'commerce_custom_product_line_item_type_reference_select') {
     $line_items_types = array_filter(
       commerce_line_item_types(),
-      function ($item) { return $item['product']; }
+      function ($item) { return !$item['product']; }
     );
 
     $options = array(NULL => '- ' . t('None') . ' -');


### PR DESCRIPTION
1. When working with custom display settings e.g. in panels you won't get a view mode name but an array with the display settings.
   Thus we need to check if the given variable is a valid view mode name or an array with the settings to use.
2. Support ctools content type "entity field". The field settings handling needed some adjustments to play well with the content type settings. Adjusting that form isn't too easy. Tried to re-use as much code as possible.
3. Added README.md to have a minimal set on instructions.
4. As discussed via Skype - only allow "non-product" line item types as "additional line item types".
5. commerce_custom_product_add_to_cart_form_submit() created line items with the order set to 0 - on my system this caused creating a new order whenever a order refresh was processed (every request!). If there wasn't a specific reason why it was set to 0 I'd suggest to re-use the order id.
